### PR TITLE
🔌 fix: retry on connection drop during fine-tuning poll

### DIFF
--- a/geospatial-studio-sdk/geostudio/backends/base_client.py
+++ b/geospatial-studio-sdk/geostudio/backends/base_client.py
@@ -19,6 +19,8 @@ from ..exceptions import GeoFMException
 from ..session import gfm_session
 
 
+from requests.adapters import HTTPAdapter
+from urllib3.util.retry import Retry
 class ResponseFormats(str, Enum):
     """
     An enumeration representing the supported output formats.
@@ -208,6 +210,14 @@ class BaseClient:
         #         well_known_url=self.api_config.ISV_WELL_KNOWN,
         #         userinfo_endpoint=self.api_config.ISV_USER_ENDPOINT,
         #     )
+
+        retry_strategy = Retry(
+            total=3,
+            backoff_factor=1,
+        )
+        adapter = HTTPAdapter(max_retries=retry_strategy)
+        self.session.mount("http://", adapter)
+        self.session.mount("https://", adapter)
         self.logger = logging.getLogger()
 
     # @property
@@ -226,7 +236,6 @@ class BaseClient:
             params (dict, optional): Query parameters to include in the GET request.
             output (str, optional): The desired output format.
             data_field (str, optional): The name of the data field to extract from the response.
-
         Returns:
             object: The response data in the specified format.
         """

--- a/geospatial-studio-sdk/geostudio/backends/base_client.py
+++ b/geospatial-studio-sdk/geostudio/backends/base_client.py
@@ -208,7 +208,6 @@ class BaseClient:
         #         well_known_url=self.api_config.ISV_WELL_KNOWN,
         #         userinfo_endpoint=self.api_config.ISV_USER_ENDPOINT,
         #     )
-
         self.logger = logging.getLogger()
 
     # @property
@@ -227,6 +226,7 @@ class BaseClient:
             params (dict, optional): Query parameters to include in the GET request.
             output (str, optional): The desired output format.
             data_field (str, optional): The name of the data field to extract from the response.
+
         Returns:
             object: The response data in the specified format.
         """

--- a/geospatial-studio-sdk/geostudio/backends/base_client.py
+++ b/geospatial-studio-sdk/geostudio/backends/base_client.py
@@ -19,8 +19,6 @@ from ..exceptions import GeoFMException
 from ..session import gfm_session
 
 
-from requests.adapters import HTTPAdapter
-from urllib3.util.retry import Retry
 class ResponseFormats(str, Enum):
     """
     An enumeration representing the supported output formats.
@@ -211,13 +209,6 @@ class BaseClient:
         #         userinfo_endpoint=self.api_config.ISV_USER_ENDPOINT,
         #     )
 
-        retry_strategy = Retry(
-            total=3,
-            backoff_factor=1,
-        )
-        adapter = HTTPAdapter(max_retries=retry_strategy)
-        self.session.mount("http://", adapter)
-        self.session.mount("https://", adapter)
         self.logger = logging.getLogger()
 
     # @property

--- a/geospatial-studio-sdk/geostudio/backends/v2/ginference/client.py
+++ b/geospatial-studio-sdk/geostudio/backends/v2/ginference/client.py
@@ -5,6 +5,7 @@
 import json
 import mimetypes
 import os
+import random
 import xml.etree.ElementTree as ET
 from datetime import datetime, timezone
 from pathlib import Path
@@ -437,8 +438,9 @@ class Client(BaseClient):
         Returns:
             dict: The response from the inference task when it is completed or failed.
         """
-        poll_frequency = 10 if poll_frequency < 10 else poll_frequency
+        poll_frequency = max(poll_frequency, 10)
         finished = False
+        max_poll_frequency = 120
 
         while finished is False:
             r = self.get_inference(inference_id)
@@ -466,7 +468,10 @@ class Client(BaseClient):
             else:
                 print(status + " - " + str(time_taken) + " seconds", end="\r")
 
-            sleep(poll_frequency)
+            jitter = random.uniform(0.8,1.2)
+            actual_sleep = poll_frequency * jitter
+            sleep(actual_sleep)
+            poll_frequency = min(poll_frequency * 1.5, max_poll_frequency)
 
     ##############################################
     #   Geoserver layers

--- a/geospatial-studio-sdk/geostudio/backends/v2/gtune/client.py
+++ b/geospatial-studio-sdk/geostudio/backends/v2/gtune/client.py
@@ -770,8 +770,9 @@ class Client(BaseClient):
             dict: The final status of the dataset, either "Succeeded" or "Failed".
         """
         # Default to a minimum of 10 seconds poll frequency.
-        poll_frequency = 10 if poll_frequency < 10 else poll_frequency
+        poll_frequency = max(poll_frequency, 10)
         finished = False
+        max_poll_frequency = 120
 
         while finished is False:
             r = self.get_dataset(dataset_id)
@@ -794,7 +795,10 @@ class Client(BaseClient):
             else:
                 print(status + " - " + str(time_taken) + " seconds", end="\r")
 
-            sleep(poll_frequency)
+            jitter = random.uniform(0.8,1.2)
+            actual_sleep = poll_frequency * jitter
+            sleep(actual_sleep)
+            poll_frequency = min(poll_frequency * 1.5, max_poll_frequency)
 
     def poll_finetuning_until_finished(self, tune_id, poll_frequency=10):
         """

--- a/geospatial-studio-sdk/geostudio/backends/v2/gtune/client.py
+++ b/geospatial-studio-sdk/geostudio/backends/v2/gtune/client.py
@@ -5,6 +5,7 @@
 import json
 import os
 from datetime import datetime, timezone
+import random
 from time import sleep
 from typing import Any
 
@@ -807,11 +808,11 @@ class Client(BaseClient):
             dict: The final status of the tune, including details such as the number of epochs and any error messages if the tune failed.
         """
         # Default to a minimum of 10 seconds poll frequency.
-        poll_frequency = 10 if poll_frequency < 10 else poll_frequency
+        poll_frequency = max(poll_frequency, 10)
         finished = False
-
+        max_poll_frequency = 120
         while finished is False:
-            r = self.get_tune(tune_id)
+            r: Response | DataFrame | Dict[str, Any | str] = self.get_tune(tune_id)
             status = r["status"]
             time_taken = (
                 datetime.now(timezone.utc)
@@ -839,4 +840,8 @@ class Client(BaseClient):
             else:
                 print(status + " - Epoch: " + str(m_epochs) + " - " + str(time_taken) + " seconds", end="\r")
 
-            sleep(poll_frequency)
+            jitter = random.uniform(0.8,1.2)
+            actual_sleep = poll_frequency * jitter
+            sleep(actual_sleep)
+            poll_frequency = min(poll_frequency * 1.5, max_poll_frequency)
+

--- a/geospatial-studio-sdk/geostudio/session.py
+++ b/geospatial-studio-sdk/geostudio/session.py
@@ -81,8 +81,6 @@ def gfm_session(
         }
 
     session = requests.Session()
-    # retries = requests.adapters.Retry(total=max_retry or False, backoff_factor=1, status_forcelist=[502, 503, 504])
-    # session.mount("https://", requests.adapters.HTTPAdapter(max_retries=retries))
     retries = requests.adapters.Retry(
         total=max_retry or 3,
         backoff_factor=1,

--- a/geospatial-studio-sdk/geostudio/session.py
+++ b/geospatial-studio-sdk/geostudio/session.py
@@ -81,8 +81,18 @@ def gfm_session(
         }
 
     session = requests.Session()
-    retries = requests.adapters.Retry(total=max_retry or False, backoff_factor=1, status_forcelist=[502, 503, 504])
-    session.mount("https://", requests.adapters.HTTPAdapter(max_retries=retries))
+    # retries = requests.adapters.Retry(total=max_retry or False, backoff_factor=1, status_forcelist=[502, 503, 504])
+    # session.mount("https://", requests.adapters.HTTPAdapter(max_retries=retries))
+    retries = requests.adapters.Retry(
+        total=max_retry or 3,
+        backoff_factor=1,
+        status_forcelist=[502, 503, 504],
+        connect=3,  # connection errors
+        read=3,     # read errors (RemoteDisconnected)
+    )
+    adapter = requests.adapters.HTTPAdapter(max_retries=retries)
+    session.mount("https://", adapter)
+    session.mount("http://", adapter)
     session.request = functools.partial(session.request, timeout=timeout)
 
     session.headers.update(request_headers)


### PR DESCRIPTION
## Summary

This PR fixes the Remote connection closed error during  polling  (Fine-tuning polling error: ('Connection aborted.', RemoteDisconnected('Remote end closed connection without response'))

It adds:
pollling with exponential back off and with jitter to spread out the load
retries using httpadpater and the request library for http request
## Related Issue (optional)

<!-- e.g. Fixes #123 -->

## How to test this PR?

<!-- Describe how you tested your changes: -->
<!-- Include commands if relevant: -->

## Screenshots / Logs (optional)

<!-- Attach any relevant logs or screenshots. -->

## Checklist

- [ ] This PR targets the main branch
- [ ] I have added or updated relevant docs.
- [ ] I have not included any secrets or credentials.
- [ ] Linting and formatting checks pass.
